### PR TITLE
adjustments for small payload changes

### DIFF
--- a/src/main/java/com/cargo_signal/bi/service/ShipmentsService.java
+++ b/src/main/java/com/cargo_signal/bi/service/ShipmentsService.java
@@ -154,8 +154,6 @@ public class ShipmentsService {
       if (response.getStatusLine().getStatusCode() == 200) {
         String result = IOUtils.toString((response.getEntity().getContent()), StandardCharsets.UTF_8);
         return result;
-      } else if (response.getStatusLine().getStatusCode() == 404) {
-        return "[]"; // FIXME endpoint should return empty list instead of 404
       } else {
         throw new RuntimeException("Failed : HTTP error code : " + response.getStatusLine().getStatusCode());
       }

--- a/src/main/java/com/cargo_signal/bi/service/domain/Shipment.java
+++ b/src/main/java/com/cargo_signal/bi/service/domain/Shipment.java
@@ -10,7 +10,7 @@ public class Shipment {
   private String shipmentNumber;
   private String referenceNumber;
   private String customer;
-//  private List<String> serviceProvider; // FIXME looks wrong in payload, array with one null
+  private List<String> serviceProvider;
   private String status;
   private String scheduledPickupTime;
   private Location pickupLocation;
@@ -31,6 +31,10 @@ public class Shipment {
 
   public String getCustomer() {
     return customer;
+  }
+
+  public List<String> getServiceProvider() {
+    return serviceProvider;
   }
 
   public String getStatus() {
@@ -81,6 +85,7 @@ public class Shipment {
         .append(shipmentNumber, shipment.shipmentNumber)
         .append(referenceNumber, shipment.referenceNumber)
         .append(customer, shipment.customer)
+        .append(serviceProvider, shipment.serviceProvider)
         .append(status, shipment.status)
         .append(scheduledPickupTime, shipment.scheduledPickupTime)
         .append(pickupLocation, shipment.pickupLocation)
@@ -99,6 +104,7 @@ public class Shipment {
         .append(shipmentNumber)
         .append(referenceNumber)
         .append(customer)
+        .append(serviceProvider)
         .append(status)
         .append(scheduledPickupTime)
         .append(pickupLocation)


### PR DESCRIPTION
Endpoints now return empty list instead of 404, adjusted logic accordingly.

Shipment payload no longer returns serviceProvider array with a null in it, instead an empty list.