### PR TITLE
Increase function timeout from default 5 minutes to max 10 minutes

### DIFF
--- a/host.json
+++ b/host.json
@@ -1,7 +1,8 @@
 {
   "version": "2.0",
+  "functionTimeout": "00:10:00",
   "extensionBundle": {
     "id": "Microsoft.Azure.Functions.ExtensionBundle",
     "version": "[1.*, 2.0.0)"
-  } 
+  }
 }


### PR DESCRIPTION
https://gitlab.cargosignal.dev/cargo-signal/intake/-/issues/1337

https://build5nines.com/azure-functions-extend-execution-timeout-past-5-minutes/#:~:text=The%20Azure%20Function%20Timeout%20is,Plan%20and%20Premium%20Plan%20pricing.